### PR TITLE
Implement Basic Repair Function for JSON Strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
         <antlr4.version>4.8</antlr4.version>
         <junit.version>5.8.2</junit.version>
+        <xstream.version>1.4.21</xstream.version>
 
         <antlr4-maven-plugin.version>4.8</antlr4-maven-plugin.version>
         <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
@@ -33,6 +34,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>${xstream.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/haibiiin/json/repair/Expecting.java
+++ b/src/main/java/io/github/haibiiin/json/repair/Expecting.java
@@ -15,6 +15,7 @@
  */
 package io.github.haibiiin.json.repair;
 
+import io.github.haibiiin.json.repair.antlr.KeySymbol;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +35,7 @@ public class Expecting {
         return list.isEmpty();
     }
     
-    public Node node() {
+    public Node first() {
         return this.list.get(0);
     }
     
@@ -62,6 +63,10 @@ public class Expecting {
         
         public List<String> expectingList() {
             return expectingList;
+        }
+        
+        public boolean isEOF() {
+            return KeySymbol.EOF.val().equalsIgnoreCase(this.key);
         }
     }
 }

--- a/src/main/java/io/github/haibiiin/json/repair/Expecting.java
+++ b/src/main/java/io/github/haibiiin/json/repair/Expecting.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Expecting {
+    
+    private List<Node> list;
+    
+    public Expecting() {
+        this.list = new ArrayList<>();
+    }
+    
+    public void add(int index, String key, List<String> expectinList) {
+        this.list.add(new Node(index, key, expectinList));
+    }
+    
+    public boolean none() {
+        return list.isEmpty();
+    }
+    
+    public Node node() {
+        return this.list.get(0);
+    }
+    
+    public class Node {
+        
+        private int index;
+        
+        private String key;
+        
+        private List<String> expectingList;
+        
+        public Node(int index, String key, List<String> expectingList) {
+            this.index = index;
+            this.key = key;
+            this.expectingList = expectingList;
+        }
+        
+        public int index() {
+            return index;
+        }
+        
+        public String key() {
+            return key;
+        }
+        
+        public List<String> expectingList() {
+            return expectingList;
+        }
+    }
+}

--- a/src/main/java/io/github/haibiiin/json/repair/Fixer.java
+++ b/src/main/java/io/github/haibiiin/json/repair/Fixer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair;
+
+import io.github.haibiiin.json.repair.antlr.DefaultErrorStrategyWrapper;
+import io.github.haibiiin.json.repair.antlr.SyntaxErrorListener;
+import io.github.haibiiin.json.repair.antlr.autogen.JSONLexer;
+import io.github.haibiiin.json.repair.antlr.autogen.JSONParser;
+import io.github.haibiiin.json.repair.strategy.SimpleRepairStrategy;
+import java.util.List;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+public class Fixer {
+    
+    private final RepairStrategy repairStrategy;
+    
+    public Fixer() {
+        this.repairStrategy = new SimpleRepairStrategy();
+    }
+    
+    public String repair(String beRepairJSON) {
+        CharStream charStream = CharStreams.fromString(beRepairJSON);
+        JSONLexer lexer = new JSONLexer(charStream);
+        JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
+        Expecting expecting = new Expecting();
+        SyntaxErrorListener syntaxErrorListener = new SyntaxErrorListener(new DefaultErrorStrategyWrapper(), expecting);
+        parser.addErrorListener(syntaxErrorListener);
+        JSONParser.JsonContext ctx = parser.json();
+        
+        if (correct(expecting)) {
+            return beRepairJSON;
+        }
+        
+        List<ParseTree> beRepairParseList = ParserListBuilder.build(ctx);
+        String repairJSON = repairStrategy.repair(beRepairJSON, beRepairParseList, expecting);
+        
+        return repair(repairJSON);
+    }
+    
+    private boolean correct(Expecting expecting) {
+        return expecting.none();
+    }
+    
+}

--- a/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
+++ b/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
@@ -26,15 +26,15 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 
-public class Fixer {
+public class JSONRepair {
     
     private final RepairStrategy repairStrategy;
     
-    public Fixer() {
+    public JSONRepair() {
         this.repairStrategy = new SimpleRepairStrategy();
     }
     
-    public String repair(String beRepairJSON) {
+    public String handle(String beRepairJSON) {
         CharStream charStream = CharStreams.fromString(beRepairJSON);
         JSONLexer lexer = new JSONLexer(charStream);
         JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
@@ -50,7 +50,7 @@ public class Fixer {
         List<ParseTree> beRepairParseList = ParserListBuilder.build(ctx);
         String repairJSON = repairStrategy.repair(beRepairJSON, beRepairParseList, expecting);
         
-        return repair(repairJSON);
+        return handle(repairJSON);
     }
     
     private boolean correct(Expecting expecting) {

--- a/src/main/java/io/github/haibiiin/json/repair/ParserListBuilder.java
+++ b/src/main/java/io/github/haibiiin/json/repair/ParserListBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+public class ParserListBuilder {
+    
+    static public List<ParseTree> build(ParseTree parseTree) {
+        List<ParseTree> list = new ArrayList<>();
+        loop(parseTree, list);
+        return list;
+    }
+    
+    static private void loop(ParseTree parseTree, List<ParseTree> list) {
+        int count = parseTree.getChildCount();
+        if (count < 1) {
+            return;
+        }
+        for (int i = 0; i < count; i++) {
+            ParseTree pt = parseTree.getChild(i);
+            list.add(pt);
+            loop(pt, list);
+        }
+    }
+    
+}

--- a/src/main/java/io/github/haibiiin/json/repair/RepairStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/RepairStrategy.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair;
+
+import java.util.List;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+public interface RepairStrategy {
+    
+    String repair(String json, List<ParseTree> beRepairParseList, Expecting expecting);
+    
+}

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/DefaultErrorStrategyWrapper.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/DefaultErrorStrategyWrapper.java
@@ -25,6 +25,10 @@ public class DefaultErrorStrategyWrapper extends DefaultErrorStrategy {
     
     @Override
     public String getTokenErrorDisplay(Token t) {
-        return super.getTokenErrorDisplay(t);
+        String defaultErrorDisplay = super.getTokenErrorDisplay(t);
+        if (defaultErrorDisplay.startsWith("'") && defaultErrorDisplay.endsWith("'")) {
+            return defaultErrorDisplay.substring(1, defaultErrorDisplay.length() - 1);
+        }
+        return defaultErrorDisplay;
     }
 }

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/DefaultErrorStrategyWrapper.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/DefaultErrorStrategyWrapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.antlr;
+
+import org.antlr.v4.runtime.DefaultErrorStrategy;
+import org.antlr.v4.runtime.Token;
+
+public class DefaultErrorStrategyWrapper extends DefaultErrorStrategy {
+    
+    public DefaultErrorStrategyWrapper() {
+    }
+    
+    @Override
+    public String getTokenErrorDisplay(Token t) {
+        return super.getTokenErrorDisplay(t);
+    }
+}

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/IntervalSetSimplifiedWrapper.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/IntervalSetSimplifiedWrapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.antlr;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.antlr.v4.runtime.Vocabulary;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.misc.IntervalSet;
+
+public class IntervalSetSimplifiedWrapper extends IntervalSet {
+    
+    public IntervalSetSimplifiedWrapper(IntervalSet set) {
+        super(set);
+    }
+    
+    public List<String> toStringList(Vocabulary vocabulary) {
+        List<String> list = new ArrayList<>();
+        if (this.intervals != null && !this.intervals.isEmpty()) {
+            
+            for (Interval I : this.intervals) {
+                int a = I.a;
+                int b = I.b;
+                if (a == b) {
+                    list.add(this.elementName(vocabulary, a));
+                } else {
+                    for (int i = a; i <= b; ++i) {
+                        list.add(this.elementName(vocabulary, i));
+                    }
+                }
+            }
+        }
+        return list;
+    }
+}

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/KeySymbol.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/KeySymbol.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.antlr;
+
+public enum KeySymbol {
+    
+    L_BRACE("{"),
+    R_BRACE("}"),
+    L_BRACKET("["),
+    R_BRACKET("]"),
+    COMMA(","),
+    COLON(":"),
+    STRING("STRING"),
+    NUMBER("NUMBER"),
+    TRUE("true"),
+    FALSE("false"),
+    NULL("null"),
+    EOF("<EOF>");
+    
+    private String val;
+    
+    KeySymbol(String val) {
+        this.val = val;
+    }
+    
+    public String val() {
+        return val;
+    }
+}

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/KeySymbol.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/KeySymbol.java
@@ -42,16 +42,15 @@ public enum KeySymbol {
     public String val() {
         return val;
     }
-
+    
     public static List<String> value() {
         return Arrays.asList(STRING.val, NUMBER.val, TRUE.val, FALSE.val, NULL.val, L_BRACE.val, L_BRACKET.val);
     }
-
+    
     public static List<String> obj() {
         return Arrays.asList(
                 STRING.val, NUMBER.val, TRUE.val, FALSE.val, NULL.val,
                 L_BRACE.val, R_BRACE.val, L_BRACKET.val, R_BRACKET.val,
-                COLON.val, COMMA.val
-        );
+                COLON.val, COMMA.val);
     }
 }

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/KeySymbol.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/KeySymbol.java
@@ -15,6 +15,9 @@
  */
 package io.github.haibiiin.json.repair.antlr;
 
+import java.util.Arrays;
+import java.util.List;
+
 public enum KeySymbol {
     
     L_BRACE("{"),
@@ -38,5 +41,17 @@ public enum KeySymbol {
     
     public String val() {
         return val;
+    }
+
+    public static List<String> value() {
+        return Arrays.asList(STRING.val, NUMBER.val, TRUE.val, FALSE.val, NULL.val, L_BRACE.val, L_BRACKET.val);
+    }
+
+    public static List<String> obj() {
+        return Arrays.asList(
+                STRING.val, NUMBER.val, TRUE.val, FALSE.val, NULL.val,
+                L_BRACE.val, R_BRACE.val, L_BRACKET.val, R_BRACKET.val,
+                COLON.val, COMMA.val
+        );
     }
 }

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
@@ -42,7 +42,7 @@ public class SyntaxErrorListener implements ANTLRErrorListener {
             
             IntervalSet expectingSet = ((JSONParser) recognizer).getExpectedTokens();
             IntervalSetSimplifiedWrapper expectingWrapper = new IntervalSetSimplifiedWrapper(expectingSet);
-            List<String> expectingStrs = expectingWrapper.toStringList(recognizer.getVocabulary());
+            List<String> expectingStrs = expectingWrapper.toStringList(new VocabularyWrapper(recognizer.getVocabulary()));
             
             this.expecting.add(i1, expectingKey, expectingStrs);
         }

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.antlr;
+
+import io.github.haibiiin.json.repair.Expecting;
+import io.github.haibiiin.json.repair.antlr.autogen.JSONParser;
+import java.util.BitSet;
+import java.util.List;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.dfa.DFA;
+import org.antlr.v4.runtime.misc.IntervalSet;
+
+public class SyntaxErrorListener implements ANTLRErrorListener {
+    
+    private DefaultErrorStrategyWrapper strategyWrapper;
+    private Expecting expecting;
+    
+    public SyntaxErrorListener(DefaultErrorStrategyWrapper strategyWrapper, Expecting expecting) {
+        this.strategyWrapper = strategyWrapper;
+        this.expecting = expecting;
+    }
+    
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer, Object o, int i, int i1, String s, RecognitionException e) {
+        if (recognizer instanceof JSONParser) {
+            Token token = ((JSONParser) recognizer).getCurrentToken();
+            String expectingKey = strategyWrapper.getTokenErrorDisplay(token);
+            
+            IntervalSet expectingSet = ((JSONParser) recognizer).getExpectedTokens();
+            IntervalSetSimplifiedWrapper expectingWrapper = new IntervalSetSimplifiedWrapper(expectingSet);
+            List<String> expectingStrs = expectingWrapper.toStringList(recognizer.getVocabulary());
+            
+            this.expecting.add(i1, expectingKey, expectingStrs);
+        }
+    }
+    
+    @Override
+    public void reportAmbiguity(Parser parser, DFA dfa, int i, int i1, boolean b, BitSet bitSet, ATNConfigSet atnConfigSet) {
+        
+    }
+    
+    @Override
+    public void reportAttemptingFullContext(Parser parser, DFA dfa, int i, int i1, BitSet bitSet, ATNConfigSet atnConfigSet) {
+        
+    }
+    
+    @Override
+    public void reportContextSensitivity(Parser parser, DFA dfa, int i, int i1, int i2, ATNConfigSet atnConfigSet) {
+        
+    }
+}

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
@@ -17,6 +17,8 @@ package io.github.haibiiin.json.repair.antlr;
 
 import io.github.haibiiin.json.repair.Expecting;
 import io.github.haibiiin.json.repair.antlr.autogen.JSONParser;
+
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 import org.antlr.v4.runtime.*;
@@ -39,11 +41,19 @@ public class SyntaxErrorListener implements ANTLRErrorListener {
         if (recognizer instanceof JSONParser) {
             Token token = ((JSONParser) recognizer).getCurrentToken();
             String expectingKey = strategyWrapper.getTokenErrorDisplay(token);
-            
-            IntervalSet expectingSet = ((JSONParser) recognizer).getExpectedTokens();
-            IntervalSetSimplifiedWrapper expectingWrapper = new IntervalSetSimplifiedWrapper(expectingSet);
-            List<String> expectingStrs = expectingWrapper.toStringList(new VocabularyWrapper(recognizer.getVocabulary()));
-            
+            List<String> expectingStrs = new ArrayList<>();
+            if (e instanceof NoViableAltException) {
+                if (KeySymbol.L_BRACKET.val().equalsIgnoreCase(expectingKey)) {
+                    expectingStrs = KeySymbol.value();
+                }
+                if (KeySymbol.L_BRACE.val().equalsIgnoreCase(expectingKey)) {
+                    expectingStrs = KeySymbol.obj();
+                }
+            } else {
+                IntervalSet expectingSet = ((JSONParser) recognizer).getExpectedTokens();
+                IntervalSetSimplifiedWrapper expectingWrapper = new IntervalSetSimplifiedWrapper(expectingSet);
+                expectingStrs = expectingWrapper.toStringList(new VocabularyWrapper(recognizer.getVocabulary()));
+            }
             this.expecting.add(i1, expectingKey, expectingStrs);
         }
     }

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
@@ -17,7 +17,6 @@ package io.github.haibiiin.json.repair.antlr;
 
 import io.github.haibiiin.json.repair.Expecting;
 import io.github.haibiiin.json.repair.antlr.autogen.JSONParser;
-
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/VocabularyWrapper.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/VocabularyWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.antlr;
+
+import org.antlr.v4.runtime.Vocabulary;
+
+public class VocabularyWrapper implements Vocabulary {
+    
+    private final Vocabulary vocabulary;
+    
+    public VocabularyWrapper(Vocabulary vocabulary) {
+        this.vocabulary = vocabulary;
+    }
+    
+    @Override
+    public int getMaxTokenType() {
+        return this.vocabulary.getMaxTokenType();
+    }
+    
+    @Override
+    public String getLiteralName(int i) {
+        return this.vocabulary.getLiteralName(i);
+    }
+    
+    @Override
+    public String getSymbolicName(int i) {
+        return this.vocabulary.getSymbolicName(i);
+    }
+    
+    @Override
+    public String getDisplayName(int i) {
+        String defaultDisplayName = this.vocabulary.getDisplayName(i);
+        if (defaultDisplayName.startsWith("'") && defaultDisplayName.endsWith("'")) {
+            return defaultDisplayName.substring(1, defaultDisplayName.length() - 1);
+        }
+        return defaultDisplayName;
+    }
+}

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
@@ -17,13 +17,76 @@ package io.github.haibiiin.json.repair.strategy;
 
 import io.github.haibiiin.json.repair.Expecting;
 import io.github.haibiiin.json.repair.RepairStrategy;
+import io.github.haibiiin.json.repair.antlr.KeySymbol;
 import java.util.List;
-import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.*;
 
 public class SimpleRepairStrategy implements RepairStrategy {
     
     @Override
     public String repair(String json, List<ParseTree> beRepairParseList, Expecting expecting) {
+        Expecting.Node node = expecting.first();
+        if (node.isEOF()) {
+            if (endObjOrPair(node.expectingList())) {
+                return json + KeySymbol.R_BRACE.val();
+            }
+            if (endArrOrValue(node.expectingList())) {
+                return json + KeySymbol.R_BRACKET.val();
+            }
+            if (startPair(node.expectingList())) {
+                int index = getCharPositionInLineFromErrorNode(beRepairParseList);
+                return json.substring(0, index) + KeySymbol.R_BRACE.val();
+            }
+            if (expectingValue(node.expectingList())) {
+                if (expectingArrValue(json)) {
+                    int index = getCharPositionInLineFromErrorNode(beRepairParseList);
+                    return json.substring(0, index) + KeySymbol.R_BRACKET.val();
+                }
+            }
+        }
         return json;
+    }
+    
+    private boolean endObjOrPair(List<String> expectingList) {
+        return expectingList.size() == 2
+                && expectingList.contains(KeySymbol.COMMA.val())
+                && expectingList.contains(KeySymbol.R_BRACE.val());
+    }
+    
+    private boolean endArrOrValue(List<String> expectingList) {
+        return expectingList.size() == 2
+                && expectingList.contains(KeySymbol.COMMA.val())
+                && expectingList.contains(KeySymbol.R_BRACKET.val());
+    }
+    
+    private boolean startPair(List<String> expectingList) {
+        return expectingList.size() == 1
+                && expectingList.contains(KeySymbol.STRING.val());
+    }
+    
+    private boolean expectingValue(List<String> expectingList) {
+        return expectingList.size() == 7
+                && expectingList.contains(KeySymbol.L_BRACE.val())
+                && expectingList.contains(KeySymbol.L_BRACKET.val())
+                && expectingList.contains(KeySymbol.TRUE.val())
+                && expectingList.contains(KeySymbol.FALSE.val())
+                && expectingList.contains(KeySymbol.NULL.val())
+                && expectingList.contains(KeySymbol.STRING.val())
+                && expectingList.contains(KeySymbol.NUMBER.val());
+    }
+    
+    private boolean expectingArrValue(String json) {
+        return KeySymbol.COMMA.val().equalsIgnoreCase(json.substring(json.length() - 1));
+    }
+    
+    private int getCharPositionInLineFromErrorNode(List<ParseTree> beRepairParseList) {
+        for (int i = beRepairParseList.size() - 1; i > 0; i--) {
+            ParseTree parseNode = beRepairParseList.get(i);
+            if (parseNode instanceof ErrorNode) {
+                int charPositionInLine = ((ErrorNodeImpl) (beRepairParseList.get(i))).getSymbol().getCharPositionInLine();
+                return charPositionInLine;
+            }
+        }
+        return -1;
     }
 }

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
@@ -106,19 +106,19 @@ public class SimpleRepairStrategy implements RepairStrategy {
     private boolean expectingArrValue(String json, int index) {
         return json.substring(index).contains(KeySymbol.COMMA.val());
     }
-
+    
     private boolean expectingValue(String json, int index) {
         return json.substring(index).contains(KeySymbol.COLON.val());
     }
-
+    
     private boolean expectingObj(List<String> expectingList) {
         return expectingList.size() == 11;
     }
-
+    
     private boolean expectingArr(List<String> expectingList) {
         return expectingList.size() == 7;
     }
-
+    
     private int getCharPositionInLineFromErrorNode(List<ParseTree> beRepairParseList) {
         for (int i = beRepairParseList.size() - 1; i > 0; i--) {
             ParseTree parseNode = beRepairParseList.get(i);

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.strategy;
+
+import io.github.haibiiin.json.repair.Expecting;
+import io.github.haibiiin.json.repair.RepairStrategy;
+import java.util.List;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+public class SimpleRepairStrategy implements RepairStrategy {
+    
+    @Override
+    public String repair(String json, List<ParseTree> beRepairParseList, Expecting expecting) {
+        return json;
+    }
+}

--- a/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
+++ b/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
@@ -28,7 +28,7 @@ public class FixerTests {
     @TestCaseSource(path = "/case/simple.xml", type = FixerStrategy.SIMPLE)
     @ArgumentsSource(TestCaseArgumentsProvider.class)
     public void testSimpleRepair(String anomaly, String correct) {
-        Fixer fixer = new Fixer();
-        Assertions.assertEquals(correct, fixer.repair(anomaly));
+        JSONRepair repair = new JSONRepair();
+        Assertions.assertEquals(correct, repair.handle(anomaly));
     }
 }

--- a/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
+++ b/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FixerTests {
+    
+    @Test
+    public void testSimpleRepair() {
+        String json = "{\"field\":\"value\"}";
+        Fixer fixer = new Fixer();
+        Assertions.assertEquals("{\"field\":\"value\"}", fixer.repair(json));
+    }
+}

--- a/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
+++ b/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
@@ -15,15 +15,20 @@
  */
 package io.github.haibiiin.json.repair;
 
+import io.github.haibiiin.json.repair.test.kits.FixerStrategy;
+import io.github.haibiiin.json.repair.test.kits.TestCaseArgumentsProvider;
+import io.github.haibiiin.json.repair.test.kits.TestCaseSource;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 public class FixerTests {
     
-    @Test
-    public void testSimpleRepair() {
-        String json = "{\"field\":\"value\"}";
+    @ParameterizedTest
+    @TestCaseSource(path = "/case/simple.xml", type = FixerStrategy.SIMPLE)
+    @ArgumentsSource(TestCaseArgumentsProvider.class)
+    public void testSimpleRepair(String anomaly, String correct) {
         Fixer fixer = new Fixer();
-        Assertions.assertEquals("{\"field\":\"value\"}", fixer.repair(json));
+        Assertions.assertEquals(correct, fixer.repair(anomaly));
     }
 }

--- a/src/test/java/io/github/haibiiin/json/repair/test/kits/FixerStrategy.java
+++ b/src/test/java/io/github/haibiiin/json/repair/test/kits/FixerStrategy.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.test.kits;
+
+public enum FixerStrategy {
+    SIMPLE;
+}

--- a/src/test/java/io/github/haibiiin/json/repair/test/kits/TestCase.java
+++ b/src/test/java/io/github/haibiiin/json/repair/test/kits/TestCase.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.test.kits;
+
+public class TestCase {
+    
+    String anomaly;
+    
+    String correct;
+    
+    public TestCase(String anomaly, String correct) {
+        this.anomaly = anomaly;
+        this.correct = correct;
+    }
+    
+    public String anomaly() {
+        return anomaly;
+    }
+    
+    public String correct() {
+        return correct;
+    }
+}

--- a/src/test/java/io/github/haibiiin/json/repair/test/kits/TestCaseArgumentsProvider.java
+++ b/src/test/java/io/github/haibiiin/json/repair/test/kits/TestCaseArgumentsProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.test.kits;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+public class TestCaseArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<TestCaseSource> {
+    
+    String filePath;
+    
+    FixerStrategy dataType;
+    
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
+        XStream xStream = new XStream();
+        xStream.alias("test-cases", ArrayList.class);
+        xStream.alias("test-case", TestCase.class);
+        xStream.addPermission(AnyTypePermission.ANY);
+        xStream.setClassLoader(this.getClass().getClassLoader());
+        List<TestCase> testCaseList = (List<TestCase>) xStream.fromXML(this.getClass().getResource(filePath));
+        return testCaseList.stream().map((testCase) -> Arguments.of(testCase.anomaly, testCase.correct));
+    }
+    
+    @Override
+    public void accept(TestCaseSource testCaseSource) {
+        this.filePath = testCaseSource.path();
+        this.dataType = testCaseSource.type();
+    }
+}

--- a/src/test/java/io/github/haibiiin/json/repair/test/kits/TestCaseSource.java
+++ b/src/test/java/io/github/haibiiin/json/repair/test/kits/TestCaseSource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.test.kits;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ArgumentsSource(TestCaseArgumentsProvider.class)
+public @interface TestCaseSource {
+    
+    String path();
+    
+    FixerStrategy type();
+}

--- a/src/test/resources/case/simple.xml
+++ b/src/test/resources/case/simple.xml
@@ -76,4 +76,16 @@
         <anomaly>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}, </anomaly>
         <correct>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</correct>
     </test-case>
+    <test-case>
+        <anomaly>{"f": </anomaly>
+        <correct>{"f": null}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "a":[ </anomaly>
+        <correct>{"f":"v", "a":[] }</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "o":{ </anomaly>
+        <correct>{"f":"v", "o":{} }</correct>
+    </test-case>
 </test-cases>

--- a/src/test/resources/case/simple.xml
+++ b/src/test/resources/case/simple.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024 HAibiiin
+
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+
+~     http://www.apache.org/licenses/LICENSE-2.0
+
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<test-cases xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:noNamespaceSchemaLocation="../json-repair-test-cases.xsd">
+    <test-case>
+        <anomaly>{"field":"value"}</anomaly>
+        <correct>{"field":"value"}</correct>
+    </test-case>
+</test-cases>

--- a/src/test/resources/case/simple.xml
+++ b/src/test/resources/case/simple.xml
@@ -17,7 +17,63 @@
 <test-cases xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:noNamespaceSchemaLocation="../json-repair-test-cases.xsd">
     <test-case>
-        <anomaly>{"field":"value"}</anomaly>
-        <correct>{"field":"value"}</correct>
+        <anomaly>{"f":"v"</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "f2":"v2"</anomaly>
+        <correct>{"f":"v", "f2":"v2"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v",</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "f2":"v2",</anomaly>
+        <correct>{"f":"v", "f2":"v2"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":1,</anomaly>
+        <correct>{"f":1}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":1, "f2":2,</anomaly>
+        <correct>{"f":1, "f2":2}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":[1]</anomaly>
+        <correct>{"f":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "a":[1]</anomaly>
+        <correct>{"f":"v", "a":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "a":[1</anomaly>
+        <correct>{"f":"v", "a":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "a":[1,</anomaly>
+        <correct>{"f":"v", "a":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "o1":{"f1":"v1"}</anomaly>
+        <correct>{"f":"v", "o1":{"f1":"v1"}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "o1":{"f1":"v1"</anomaly>
+        <correct>{"f":"v", "o1":{"f1":"v1"}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "o1":{"f1":"v1"},</anomaly>
+        <correct>{"f":"v", "o1":{"f1":"v1"}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "o1":{"f1":"v1"}, "a":[1,</anomaly>
+        <correct>{"f":"v", "o1":{"f1":"v1"}, "a":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}, </anomaly>
+        <correct>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</correct>
     </test-case>
 </test-cases>

--- a/src/test/resources/json-repair-test-cases.xsd
+++ b/src/test/resources/json-repair-test-cases.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024 HAibiiin
+
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+
+~     http://www.apache.org/licenses/LICENSE-2.0
+
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="test-cases">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="test-case" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="anomaly" type="xs:string"/>
+                            <xs:element name="correct" type="xs:string"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
Implement the basic repair function for JSON strings. The following repair contents are supported:
- Adding the missing right parenthesis;
- Adding the missing right square bracket;
- Cleaning up the redundant commas when the value is in the form of an array;
- Filling in the missing values with "null". 
---
实现对 JSON 字符串基本修补功能，支持以下修补内容：
- 修补缺少的右括号；
- 修补缺少的右中括号；
- 值为数组情况下多余逗号清理；
- 值缺失以 null 填补。