### PR TITLE
Enhance JSON string patching functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <antlr4.version>4.8</antlr4.version>
         <junit.version>5.8.2</junit.version>
         <xstream.version>1.4.21</xstream.version>
+        <jmh.version>1.37</jmh.version>
 
         <antlr4-maven-plugin.version>4.8</antlr4-maven-plugin.version>
         <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
@@ -40,6 +41,18 @@
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <version>${xstream.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/haibiiin/json/repair/Expecting.java
+++ b/src/main/java/io/github/haibiiin/json/repair/Expecting.java
@@ -38,7 +38,11 @@ public class Expecting {
     public Node first() {
         return this.list.get(0);
     }
-    
+
+    public int sum() {
+        return this.list.size();
+    }
+
     public class Node {
         
         private int index;

--- a/src/main/java/io/github/haibiiin/json/repair/Expecting.java
+++ b/src/main/java/io/github/haibiiin/json/repair/Expecting.java
@@ -38,11 +38,11 @@ public class Expecting {
     public Node first() {
         return this.list.get(0);
     }
-
+    
     public int sum() {
         return this.list.size();
     }
-
+    
     public class Node {
         
         private int index;

--- a/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
+++ b/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
@@ -29,9 +29,27 @@ import org.antlr.v4.runtime.tree.ParseTree;
 public class JSONRepair {
     
     private final RepairStrategy repairStrategy;
-
+    
+    private final JSONRepairConfig properties;
+    
     public JSONRepair() {
         this.repairStrategy = new SimpleRepairStrategy();
+        this.properties = new JSONRepairConfig();
+    }
+    
+    public JSONRepair(RepairStrategy repairStrategy) {
+        this.repairStrategy = repairStrategy;
+        this.properties = new JSONRepairConfig();
+    }
+    
+    public JSONRepair(JSONRepairConfig config) {
+        this.repairStrategy = new SimpleRepairStrategy();
+        this.properties = config;
+    }
+    
+    public JSONRepair(RepairStrategy repairStrategy, JSONRepairConfig config) {
+        this.repairStrategy = repairStrategy;
+        this.properties = config;
     }
     
     public String handle(String beRepairJSON) throws RepairFailureException {
@@ -47,15 +65,15 @@ public class JSONRepair {
         if (correct(expecting)) {
             return beRepairJSON;
         }
-
-        int maxTryTimes = Math.max(expecting.sum(), 20);
+        
+        int maxTryTimes = Math.max(expecting.sum(), this.properties.maxTryTimes());
         
         List<ParseTree> beRepairParseList = ParserListBuilder.build(ctx);
         String repairJSON = repairStrategy.repair(beRepairJSON, beRepairParseList, expecting);
         
         return subHandle(repairJSON, maxTryTimes, 0);
     }
-
+    
     public String subHandle(String beRepairJSON, int maxTryTimes, int tryTimes) {
         if (tryTimes == maxTryTimes) {
             throw new OverstepTryTimesException();
@@ -68,7 +86,7 @@ public class JSONRepair {
         lexer.addErrorListener(syntaxErrorListener);
         parser.addErrorListener(syntaxErrorListener);
         JSONParser.JsonContext ctx = parser.json();
-
+        
         if (correct(expecting)) {
             return beRepairJSON;
         }

--- a/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
+++ b/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
@@ -58,8 +58,12 @@ public class JSONRepair {
         JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
         Expecting expecting = new Expecting();
         SyntaxErrorListener syntaxErrorListener = new SyntaxErrorListener(new DefaultErrorStrategyWrapper(), expecting);
+
+        lexer.removeErrorListeners();
+        parser.removeErrorListeners();
         lexer.addErrorListener(syntaxErrorListener);
         parser.addErrorListener(syntaxErrorListener);
+
         JSONParser.JsonContext ctx = parser.json();
         
         if (correct(expecting)) {
@@ -83,8 +87,12 @@ public class JSONRepair {
         JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
         Expecting expecting = new Expecting();
         SyntaxErrorListener syntaxErrorListener = new SyntaxErrorListener(new DefaultErrorStrategyWrapper(), expecting);
+
+        lexer.removeErrorListeners();
+        parser.removeErrorListeners();
         lexer.addErrorListener(syntaxErrorListener);
         parser.addErrorListener(syntaxErrorListener);
+
         JSONParser.JsonContext ctx = parser.json();
         
         if (correct(expecting)) {

--- a/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
+++ b/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
@@ -40,6 +40,7 @@ public class JSONRepair {
         JSONParser parser = new JSONParser(new CommonTokenStream(lexer));
         Expecting expecting = new Expecting();
         SyntaxErrorListener syntaxErrorListener = new SyntaxErrorListener(new DefaultErrorStrategyWrapper(), expecting);
+        lexer.addErrorListener(syntaxErrorListener);
         parser.addErrorListener(syntaxErrorListener);
         JSONParser.JsonContext ctx = parser.json();
         

--- a/src/main/java/io/github/haibiiin/json/repair/JSONRepairConfig.java
+++ b/src/main/java/io/github/haibiiin/json/repair/JSONRepairConfig.java
@@ -15,17 +15,26 @@
  */
 package io.github.haibiiin.json.repair;
 
-public class OverstepTryTimesException extends RepairFailureException {
+import java.util.Properties;
+
+public class JSONRepairConfig {
     
-    public OverstepTryTimesException() {
-        super();
+    private final Properties properties;
+    
+    public JSONRepairConfig() {
+        this.properties = new Properties();
+        this.properties.put(Property.MAX_TRY_TIMES.name(), 20);
     }
     
-    public OverstepTryTimesException(String message) {
-        super(message);
+    public int maxTryTimes() {
+        return (int) this.properties.getOrDefault(Property.MAX_TRY_TIMES.name(), 20);
     }
     
-    public OverstepTryTimesException(String message, Throwable cause) {
-        super(message, cause);
+    public void maxTryTimes(int value) {
+        this.properties.put(Property.MAX_TRY_TIMES.name(), value);
+    }
+    
+    public enum Property {
+        MAX_TRY_TIMES;
     }
 }

--- a/src/main/java/io/github/haibiiin/json/repair/OverstepTryTimesException.java
+++ b/src/main/java/io/github/haibiiin/json/repair/OverstepTryTimesException.java
@@ -1,0 +1,16 @@
+package io.github.haibiiin.json.repair;
+
+public class OverstepTryTimesException extends RepairFailureException {
+
+    public OverstepTryTimesException() {
+        super();
+    }
+
+    public OverstepTryTimesException(String message) {
+        super(message);
+    }
+
+    public OverstepTryTimesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/haibiiin/json/repair/RepairFailureException.java
+++ b/src/main/java/io/github/haibiiin/json/repair/RepairFailureException.java
@@ -1,15 +1,30 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.haibiiin.json.repair;
 
 public class RepairFailureException extends RuntimeException {
-
+    
     public RepairFailureException() {
         super();
     }
-
+    
     public RepairFailureException(String message) {
         super(message);
     }
-
+    
     public RepairFailureException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/io/github/haibiiin/json/repair/RepairFailureException.java
+++ b/src/main/java/io/github/haibiiin/json/repair/RepairFailureException.java
@@ -1,0 +1,16 @@
+package io.github.haibiiin.json.repair;
+
+public class RepairFailureException extends RuntimeException {
+
+    public RepairFailureException() {
+        super();
+    }
+
+    public RepairFailureException(String message) {
+        super(message);
+    }
+
+    public RepairFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/KeySymbol.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/KeySymbol.java
@@ -31,7 +31,8 @@ public enum KeySymbol {
     TRUE("true"),
     FALSE("false"),
     NULL("null"),
-    EOF("<EOF>");
+    EOF("<EOF>"),
+    TOKEN("token");
     
     private String val;
     

--- a/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
@@ -16,6 +16,7 @@
 package io.github.haibiiin.json.repair.antlr;
 
 import io.github.haibiiin.json.repair.Expecting;
+import io.github.haibiiin.json.repair.antlr.autogen.JSONLexer;
 import io.github.haibiiin.json.repair.antlr.autogen.JSONParser;
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -53,6 +54,12 @@ public class SyntaxErrorListener implements ANTLRErrorListener {
                 IntervalSetSimplifiedWrapper expectingWrapper = new IntervalSetSimplifiedWrapper(expectingSet);
                 expectingStrs = expectingWrapper.toStringList(new VocabularyWrapper(recognizer.getVocabulary()));
             }
+            this.expecting.add(i1, expectingKey, expectingStrs);
+        }
+        if (recognizer instanceof JSONLexer) {
+            String expectingKey = s.substring(s.indexOf("'") + 1, s.lastIndexOf("'"));
+            List<String> expectingStrs = new ArrayList<>();
+            expectingStrs.add(KeySymbol.TOKEN.val());
             this.expecting.add(i1, expectingKey, expectingStrs);
         }
     }

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
@@ -46,6 +46,10 @@ public class SimpleRepairStrategy implements RepairStrategy {
                     return json + KeySymbol.NULL.val() + KeySymbol.R_BRACE.val();
                 }
             }
+        } else if (KeySymbol.COLON.val().equalsIgnoreCase(node.key())) {
+            if (expectingEOF(node.expectingList())) {
+                return KeySymbol.L_BRACE.val() + json;
+            }
         } else {
             for (ParseTree parseNode : beRepairParseList) {
                 if (parseNode instanceof ErrorNode) {
@@ -117,6 +121,10 @@ public class SimpleRepairStrategy implements RepairStrategy {
     
     private boolean expectingArr(List<String> expectingList) {
         return expectingList.size() == 7;
+    }
+
+    private boolean expectingEOF(List<String> expectingList) {
+        return expectingList.size() == 1 && expectingList.contains(KeySymbol.EOF.val());
     }
     
     private int getCharPositionInLineFromErrorNode(List<ParseTree> beRepairParseList) {

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
@@ -50,6 +50,17 @@ public class SimpleRepairStrategy implements RepairStrategy {
             if (expectingEOF(node.expectingList())) {
                 return KeySymbol.L_BRACE.val() + json;
             }
+        } else if (this.expectingToken(node.expectingList())) {
+            if (node.key().startsWith("\"")) {
+                return json.replaceFirst(node.key(), node.key() + "\"");
+            }
+            if (node.key().endsWith("\"")) {
+                return json.replaceFirst(node.key(), "\"" + node.key());
+            }
+            if (node.key().endsWith(KeySymbol.COLON.val())) {
+                return json.replaceFirst(node.key(), "\"" + node.key().substring(0, node.key().length() - 1) + "\":");
+            }
+            return json.replaceFirst(node.key(), "\"" + node.key() + "\"");
         } else {
             for (ParseTree parseNode : beRepairParseList) {
                 if (parseNode instanceof ErrorNode) {
@@ -135,5 +146,9 @@ public class SimpleRepairStrategy implements RepairStrategy {
             }
         }
         return -1;
+    }
+
+    private boolean expectingToken(List<String> expectingList) {
+        return expectingList.size() == 1 && expectingList.contains(KeySymbol.TOKEN.val());
     }
 }

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
@@ -133,7 +133,7 @@ public class SimpleRepairStrategy implements RepairStrategy {
     private boolean expectingArr(List<String> expectingList) {
         return expectingList.size() == 7;
     }
-
+    
     private boolean expectingEOF(List<String> expectingList) {
         return expectingList.size() == 1 && expectingList.contains(KeySymbol.EOF.val());
     }
@@ -147,7 +147,7 @@ public class SimpleRepairStrategy implements RepairStrategy {
         }
         return -1;
     }
-
+    
     private boolean expectingToken(List<String> expectingList) {
         return expectingList.size() == 1 && expectingList.contains(KeySymbol.TOKEN.val());
     }

--- a/src/test/java/io/github/haibiiin/json/repair/BenchmarkTests.java
+++ b/src/test/java/io/github/haibiiin/json/repair/BenchmarkTests.java
@@ -1,0 +1,45 @@
+package io.github.haibiiin.json.repair;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class BenchmarkTests {
+
+    @Param({
+            "{\"f\":\"v\", \"f2\":\"v2\"",
+            "{\"f\":\"v\", \"a\":[1",
+            "{\"f\":\"v\", \"a\":[1,2], \"o1\":{\"f1\":\"v1\"}, ",
+            "\"f\":\"v\", \"a\":[1,2], \"o1\":{\"f1\":\"v1\"}",
+            "f:v"
+    })
+    String anomalyJSON;
+
+    @Benchmark
+    public void testSimpleRepairStrategy(Blackhole blackhole) {
+        JSONRepair repair = new JSONRepair();
+        blackhole.consume(repair.handle(anomalyJSON));
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(BenchmarkTests.class.getSimpleName())
+                .result("./reports/benchmark/benchmark_0.1.0.json")
+                .resultFormat(ResultFormatType.JSON)
+                .build();
+        new Runner(opt).run();
+    }
+
+}

--- a/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
+++ b/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 public class FixerTests {
     
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0} > {1}")
     @TestCaseSource(path = "/case/simple.xml", type = FixerStrategy.SIMPLE)
     @ArgumentsSource(TestCaseArgumentsProvider.class)
     public void testSimpleRepair(String anomaly, String correct) {

--- a/src/test/resources/case/simple.xml
+++ b/src/test/resources/case/simple.xml
@@ -88,4 +88,20 @@
         <anomaly>{"f":"v", "o":{ </anomaly>
         <correct>{"f":"v", "o":{} }</correct>
     </test-case>
+    <test-case>
+        <anomaly>"f":"v"</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>"f":"v"}</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>"f":"v", "a":[1,2], "o1":{"f1":"v1"}</anomaly>
+        <correct>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</anomaly>
+        <correct>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</correct>
+    </test-case>
 </test-cases>

--- a/src/test/resources/case/simple.xml
+++ b/src/test/resources/case/simple.xml
@@ -104,4 +104,20 @@
         <anomaly>"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</anomaly>
         <correct>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</correct>
     </test-case>
+    <test-case>
+        <anomaly>{"f":v</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{"f":"v</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>{f:v</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>f:v</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
 </test-cases>


### PR DESCRIPTION
Improve the basic patching functionality for JSON strings and add the following patching contents:

- Patch the missing left parentheses;
- Patch the missing outermost parentheses;
- Patch the lack of quotation marks for strings in individual scenarios;
- Provide the number of custom patching attempts. 
---
完善对 JSON 字符串基本修补功能，增加以下修补内容：

- 修补缺少的左括号；
- 修补缺少的最外层括号；
- 修补个别场景下字符串缺少引号；
- 提供自定义修补尝试次数。