### PR TITLE
Handle line breaks encountered during lexical parsing errors.

### DIFF
--- a/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
+++ b/src/main/java/io/github/haibiiin/json/repair/antlr/SyntaxErrorListener.java
@@ -57,11 +57,26 @@ public class SyntaxErrorListener implements ANTLRErrorListener {
             this.expecting.add(i1, expectingKey, expectingStrs);
         }
         if (recognizer instanceof JSONLexer) {
-            String expectingKey = s.substring(s.indexOf("'") + 1, s.lastIndexOf("'"));
+            String expectingKey = getExpectingKey(s);
             List<String> expectingStrs = new ArrayList<>();
             expectingStrs.add(KeySymbol.TOKEN.val());
             this.expecting.add(i1, expectingKey, expectingStrs);
         }
+    }
+    
+    private String getExpectingKey(String s) {
+        String expectingKey = s.substring(s.indexOf("'") + 1, s.lastIndexOf("'"));
+        int lastIndexOfLF = expectingKey.lastIndexOf("\\n");
+        if (lastIndexOfLF == -1) {
+            lastIndexOfLF = expectingKey.lastIndexOf("\\r");
+        }
+        if (lastIndexOfLF == -1) {
+            lastIndexOfLF = expectingKey.lastIndexOf("\\r\\n");
+        }
+        if (lastIndexOfLF != -1) {
+            expectingKey = expectingKey.substring(0, lastIndexOfLF);
+        }
+        return expectingKey;
     }
     
     @Override

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
@@ -146,7 +146,17 @@ public class SimpleRepairStrategy implements RepairStrategy {
                 (json, node, beRepairParseList) -> KeySymbol.L_BRACE.val() + json),
         CLOSE_QUOTATION_MARK(
                 (node, beRepairParseList) -> node.expectingToken() && node.key().startsWith("\""),
-                (json, node, beRepairParseList) -> json.replaceFirst(node.key(), node.key() + "\"")),
+                (json, node, beRepairParseList) -> {
+                    if (json.lastIndexOf(KeySymbol.COMMA.val()) != -1) {
+                        ParseTree errorNode = beRepairParseList.stream().filter((parse) -> parse instanceof ErrorNode).findFirst().orElse(null);
+                        if (errorNode != null && KeySymbol.COLON.val().equalsIgnoreCase(errorNode.getText())) {
+                            return json.replaceFirst(node.key(), node.key().substring(0, node.key().length() - 1) + "\",");
+                        }
+                        throw new UnableHandleException();
+                    } else {
+                        return json.replaceFirst(node.key(), node.key() + "\"");
+                    }
+                }),
         OPEN_QUOTATION_MARK(
                 (node, beRepairParseList) -> node.expectingToken() && node.key().endsWith("\""),
                 (json, node, beRepairParseList) -> json.replaceFirst(node.key(), "\"" + node.key())),

--- a/src/test/resources/case/simple.xml
+++ b/src/test/resources/case/simple.xml
@@ -120,4 +120,18 @@
         <anomaly>f:v</anomaly>
         <correct>{"f":"v"}</correct>
     </test-case>
+    <test-case>
+        <anomaly>
+            {
+                "f1":"v1,
+                "f2":"v2"
+            }
+        </anomaly>
+        <correct>
+            {
+                "f1":"v1",
+                "f2":"v2"
+            }
+        </correct>
+    </test-case>
 </test-cases>


### PR DESCRIPTION
Close #4 

- Handle line breaks encountered during lexical parsing errors.
- Fix for an abnormal scenario where a JSON lexical parsing error occurs and includes line breaks.
---
- 针对词法解析异常时的换行符处理。
- 增加一种 JSON 词法解析错误且包含换行符的异常场景的修复。