### PR TITLE
Implement simple extract json capcity 

### DIFF
--- a/src/main/java/io/github/haibiiin/json/repair/ExtractStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/ExtractStrategy.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair;
+
+import java.util.List;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+public interface ExtractStrategy {
+    
+    String extract(String content, List<ParseTree> beRepairParseList, Expecting expecting);
+    
+}

--- a/src/main/java/io/github/haibiiin/json/repair/JSONRepairConfig.java
+++ b/src/main/java/io/github/haibiiin/json/repair/JSONRepairConfig.java
@@ -24,6 +24,7 @@ public class JSONRepairConfig {
     public JSONRepairConfig() {
         this.properties = new Properties();
         this.properties.put(Property.MAX_TRY_TIMES.name(), 20);
+        this.properties.put(Property.EXTRACT_JSON.name(), false);
     }
     
     public int maxTryTimes() {
@@ -33,8 +34,17 @@ public class JSONRepairConfig {
     public void maxTryTimes(int value) {
         this.properties.put(Property.MAX_TRY_TIMES.name(), value);
     }
-    
+
+    public boolean extractJSON() {
+        return (boolean) this.properties.getOrDefault(Property.EXTRACT_JSON.name(), false);
+    }
+
+    public void enableExtractJSON() {
+        this.properties.put(Property.EXTRACT_JSON.name(), true);
+    }
+
     public enum Property {
+        EXTRACT_JSON,
         MAX_TRY_TIMES;
     }
 }

--- a/src/main/java/io/github/haibiiin/json/repair/JSONRepairConfig.java
+++ b/src/main/java/io/github/haibiiin/json/repair/JSONRepairConfig.java
@@ -34,15 +34,15 @@ public class JSONRepairConfig {
     public void maxTryTimes(int value) {
         this.properties.put(Property.MAX_TRY_TIMES.name(), value);
     }
-
+    
     public boolean extractJSON() {
         return (boolean) this.properties.getOrDefault(Property.EXTRACT_JSON.name(), false);
     }
-
+    
     public void enableExtractJSON() {
         this.properties.put(Property.EXTRACT_JSON.name(), true);
     }
-
+    
     public enum Property {
         EXTRACT_JSON,
         MAX_TRY_TIMES;

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleExtractStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleExtractStrategy.java
@@ -29,20 +29,21 @@ public class SimpleExtractStrategy implements ExtractStrategy {
     public String extract(String content, List<ParseTree> beRepairParseList, Expecting expecting) {
         if (validParseTreeList(beRepairParseList)) {
             ParseTree parseTree = beRepairParseList.get(1);
+            int start, end;
             if (parseTree instanceof JSONParser.ObjContext) {
-                int start = ((JSONParser.ObjContext) parseTree).getStart().getStartIndex();
-                int end = ((JSONParser.ObjContext) parseTree).getStop().getStopIndex();
-                return content.substring(start, end + 1);
+                start = ((JSONParser.ObjContext) parseTree).getStart().getStartIndex();
+                end = ((JSONParser.ObjContext) parseTree).getStop().getStopIndex() + 1;
+                return content.substring(start, end);
             }
             if (parseTree instanceof JSONParser.ArrContext) {
-                int start = ((JSONParser.ArrContext) parseTree).getStart().getStartIndex();
-                int end = ((JSONParser.ArrContext) parseTree).getStop().getStopIndex();
-                return content.substring(start, end + 1);
+                start = ((JSONParser.ArrContext) parseTree).getStart().getStartIndex();
+                end = ((JSONParser.ArrContext) parseTree).getStop().getStopIndex() + 1;
+                return content.substring(start, end);
             }
             if (parseTree instanceof JSONParser.ValueContext) {
-                int start = ((JSONParser.ValueContext) parseTree).getStart().getStartIndex();
-                int end = ((JSONParser.ValueContext) parseTree).getStop().getStopIndex();
-                return content.substring(start, end + 1);
+                start = ((JSONParser.ValueContext) parseTree).getStart().getStartIndex();
+                end = ((JSONParser.ValueContext) parseTree).getStop().getStopIndex() + 1;
+                return content.substring(start, end);
             }
             if (parseTree instanceof TerminalNode) {
                 String symbol = ((TerminalNode) parseTree).getSymbol().getText();

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleExtractStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleExtractStrategy.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 HAibiiin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.haibiiin.json.repair.strategy;
+
+import io.github.haibiiin.json.repair.Expecting;
+import io.github.haibiiin.json.repair.ExtractStrategy;
+import io.github.haibiiin.json.repair.antlr.KeySymbol;
+import io.github.haibiiin.json.repair.antlr.autogen.JSONParser;
+import java.util.List;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+public class SimpleExtractStrategy implements ExtractStrategy {
+    
+    @Override
+    public String extract(String content, List<ParseTree> beRepairParseList, Expecting expecting) {
+        if (validParseTreeList(beRepairParseList)) {
+            ParseTree parseTree = beRepairParseList.get(1);
+            if (parseTree instanceof JSONParser.ObjContext) {
+                int start = ((JSONParser.ObjContext) parseTree).getStart().getStartIndex();
+                int end = ((JSONParser.ObjContext) parseTree).getStop().getStopIndex();
+                return content.substring(start, end + 1);
+            }
+            if (parseTree instanceof JSONParser.ArrContext) {
+                int start = ((JSONParser.ArrContext) parseTree).getStart().getStartIndex();
+                int end = ((JSONParser.ArrContext) parseTree).getStop().getStopIndex();
+                return content.substring(start, end + 1);
+            }
+            if (parseTree instanceof JSONParser.ValueContext) {
+                int start = ((JSONParser.ValueContext) parseTree).getStart().getStartIndex();
+                int end = ((JSONParser.ValueContext) parseTree).getStop().getStopIndex();
+                return content.substring(start, end + 1);
+            }
+            if (parseTree instanceof TerminalNode) {
+                String symbol = ((TerminalNode) parseTree).getSymbol().getText();
+                
+                if (KeySymbol.TRUE.val().equalsIgnoreCase(symbol.toLowerCase())
+                        || KeySymbol.FALSE.val().equalsIgnoreCase(symbol.toLowerCase())
+                        || KeySymbol.NULL.val().equalsIgnoreCase(symbol.toLowerCase())) {
+                    return symbol;
+                }
+                if (beRepairParseList.size() == 3
+                        && beRepairParseList.get(2) instanceof TerminalNode
+                        && KeySymbol.EOF.val().equalsIgnoreCase(((TerminalNode) beRepairParseList.get(2)).getSymbol().getText())) {
+                    return symbol;
+                }
+            }
+        }
+        return content;
+    }
+    
+    private boolean validParseTreeList(List<ParseTree> parseTreeList) {
+        return parseTreeList.size() >= 2 && parseTreeList.get(0) instanceof JSONParser.ValueContext;
+    }
+}

--- a/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
+++ b/src/test/java/io/github/haibiiin/json/repair/FixerTests.java
@@ -31,4 +31,14 @@ public class FixerTests {
         JSONRepair repair = new JSONRepair();
         Assertions.assertEquals(correct, repair.handle(anomaly));
     }
+    
+    @ParameterizedTest(name = "{0} > {1}")
+    @TestCaseSource(path = "/case/extract.xml", type = FixerStrategy.SIMPLE)
+    @ArgumentsSource(TestCaseArgumentsProvider.class)
+    public void testSimpleExtract(String anomaly, String correct) {
+        JSONRepairConfig config = new JSONRepairConfig();
+        config.enableExtractJSON();
+        JSONRepair repair = new JSONRepair(config);
+        Assertions.assertEquals(correct, repair.handle(anomaly));
+    }
 }

--- a/src/test/resources/case/extract.xml
+++ b/src/test/resources/case/extract.xml
@@ -57,4 +57,92 @@
         <anomaly>json data null</anomaly>
         <correct>null</correct>
     </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v"</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "f2":"v2"</anomaly>
+        <correct>{"f":"v", "f2":"v2"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v",</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "f2":"v2",</anomaly>
+        <correct>{"f":"v", "f2":"v2"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":1,</anomaly>
+        <correct>{"f":1}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":1, "f2":2,</anomaly>
+        <correct>{"f":1, "f2":2}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":[1]</anomaly>
+        <correct>{"f":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "a":[1]</anomaly>
+        <correct>{"f":"v", "a":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "a":[1</anomaly>
+        <correct>{"f":"v", "a":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "a":[1,</anomaly>
+        <correct>{"f":"v", "a":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "o1":{"f1":"v1"}</anomaly>
+        <correct>{"f":"v", "o1":{"f1":"v1"}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "o1":{"f1":"v1"</anomaly>
+        <correct>{"f":"v", "o1":{"f1":"v1"}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "o1":{"f1":"v1"},</anomaly>
+        <correct>{"f":"v", "o1":{"f1":"v1"}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "o1":{"f1":"v1"}, "a":[1,</anomaly>
+        <correct>{"f":"v", "o1":{"f1":"v1"}, "a":[1]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "a":[1,2], "o1":{"f1":"v1"}, </anomaly>
+        <correct>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f": </anomaly>
+        <correct>{"f":null}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "a":[ </anomaly>
+        <correct>{"f":"v", "a":[]}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"f":"v", "o":{ </anomaly>
+        <correct>{"f":"v", "o":{}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>"f":"v"</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>"f":"v"}</anomaly>
+        <correct>{"f":"v"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>"f":"v", "a":[1,2], "o1":{"f1":"v1"}</anomaly>
+        <correct>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</anomaly>
+        <correct>{"f":"v", "a":[1,2], "o1":{"f1":"v1"}}</correct>
+    </test-case>
 </test-cases>

--- a/src/test/resources/case/extract.xml
+++ b/src/test/resources/case/extract.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024 HAibiiin
+
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+
+~     http://www.apache.org/licenses/LICENSE-2.0
+
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<test-cases xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:noNamespaceSchemaLocation="../json-repair-test-cases.xsd">
+    <test-case>
+        <anomaly>json data {"key":"value"}</anomaly>
+        <correct>{"key":"value"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data {"key":"value"} end</anomaly>
+        <correct>{"key":"value"}</correct>
+    </test-case>
+    <test-case>
+        <anomaly>
+            json data
+            {
+                "f1":"v1,
+                "f2":"v2"
+            }
+        </anomaly>
+        <correct>{
+                "f1":"v1",
+                "f2":"v2"
+            }</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data "value"</anomaly>
+        <correct>"value"</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data [1,2,3]</anomaly>
+        <correct>[1,2,3]</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data true</anomaly>
+        <correct>true</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data false</anomaly>
+        <correct>false</correct>
+    </test-case>
+    <test-case>
+        <anomaly>json data null</anomaly>
+        <correct>null</correct>
+    </test-case>
+</test-cases>


### PR DESCRIPTION
#10 

- Add the JSONRepairConfig configuration item to determine whether to enable the JSON extraction function.
- Implement the extraction of JSON format content from text strings.
- Determine the repair behavior according to the configuration. If the extraction function is enabled, first extract the JSON format content from the text string, and then perform detection and repair on the extracted content. 

---

- 增加 JSONRepairConfig 配置项，是否开启 JSON 提取功能；
- 实现针对文本字符串提取 JSON 格式内容；
- 根据配置确定修复行为，若开启提取功能，先对文本字符串进行 JSON 格式内容的提取，并针对提取内容进行检测与修复；