### PR TITLE
fix: repair unescaped quotes in string values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <annotations.version>24.1.0</annotations.version>
 
         <antlr4-maven-plugin.version>4.8</antlr4-maven-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
 
         <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
@@ -87,6 +88,11 @@
                         </licenseHeader>
                     </java>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.antlr</groupId>

--- a/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
+++ b/src/main/java/io/github/haibiiin/json/repair/JSONRepair.java
@@ -106,7 +106,87 @@ public class JSONRepair {
         beRepairJSON = beRepairJSON.replaceAll("\"\"([^\",:{}\\[\\]\\s]+)\"", "\"$1\"");
         // Remove non-JSON characters (e.g. parentheses) appearing after structural tokens
         beRepairJSON = beRepairJSON.replaceAll("(?<=[]},])\\s*[^\\s\\w\"{}\\[\\]:,.\\-]+\\s*(?=[]}]|$)", "");
+        beRepairJSON = escapeUnescapedStringQuotes(beRepairJSON);
         return beRepairJSON;
+    }
+    
+    private @NotNull String escapeUnescapedStringQuotes(String json) {
+        StringBuilder repaired = new StringBuilder(json.length());
+        boolean inString = false;
+        boolean escaped = false;
+        int stringStart = -1;
+        for (int i = 0; i < json.length(); i++) {
+            char current = json.charAt(i);
+            if (!inString) {
+                repaired.append(current);
+                if (current == '"') {
+                    inString = true;
+                    escaped = false;
+                    stringStart = i;
+                }
+                continue;
+            }
+            
+            if (escaped) {
+                repaired.append(current);
+                escaped = false;
+                continue;
+            }
+            
+            if (current == '\\') {
+                repaired.append(current);
+                escaped = true;
+                continue;
+            }
+            
+            if (current == '"') {
+                if (i == stringStart + 1 || isLikelyStringClosingQuote(json, i) || isLikelyStructuralQuote(json, i)) {
+                    repaired.append(current);
+                    inString = false;
+                    stringStart = -1;
+                } else {
+                    repaired.append('\\').append(current);
+                }
+                continue;
+            }
+            
+            repaired.append(current);
+        }
+        return repaired.toString();
+    }
+    
+    private boolean isLikelyStringClosingQuote(String json, int quoteIndex) {
+        int nextIndex = nextNonWhitespaceIndex(json, quoteIndex + 1);
+        if (nextIndex == json.length()) {
+            return true;
+        }
+        char next = json.charAt(nextIndex);
+        return next == ':' || next == ',' || next == '}' || next == ']';
+    }
+    
+    private boolean isLikelyStructuralQuote(String json, int quoteIndex) {
+        int previousIndex = previousNonWhitespaceIndex(json, quoteIndex - 1);
+        if (previousIndex < 0) {
+            return true;
+        }
+        char previous = json.charAt(previousIndex);
+        return previous == ':' || previous == ',' || previous == '{' || previous == '[';
+    }
+    
+    private int previousNonWhitespaceIndex(String json, int startIndex) {
+        int index = startIndex;
+        while (index >= 0 && Character.isWhitespace(json.charAt(index))) {
+            index--;
+        }
+        return index;
+    }
+    
+    private int nextNonWhitespaceIndex(String json, int startIndex) {
+        int index = startIndex;
+        while (index < json.length() && Character.isWhitespace(json.charAt(index))) {
+            index++;
+        }
+        return index;
     }
     
     public String subHandle(String beRepairJSON, int maxTryTimes, int tryTimes) {

--- a/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
+++ b/src/main/java/io/github/haibiiin/json/repair/strategy/SimpleRepairStrategy.java
@@ -40,6 +40,14 @@ public class SimpleRepairStrategy implements RepairStrategy {
         return strategy.fixStrategy.fix(json, nodeWrapper, beRepairParseList);
     }
     
+    private static String replaceFirstLiteral(String source, String target, String replacement) {
+        int index = source.indexOf(target);
+        if (index == -1) {
+            return source;
+        }
+        return source.substring(0, index) + replacement + source.substring(index + target.length());
+    }
+    
     static class SimpleNodeWrapper {
         
         private final Expecting.Node node;
@@ -164,20 +172,20 @@ public class SimpleRepairStrategy implements RepairStrategy {
                     if (json.lastIndexOf(KeySymbol.COMMA.val()) != -1) {
                         ParseTree errorNode = beRepairParseList.stream().filter((parse) -> parse instanceof ErrorNode).findFirst().orElse(null);
                         if (errorNode != null && KeySymbol.COLON.val().equalsIgnoreCase(errorNode.getText())) {
-                            return json.replaceFirst(node.key(), node.key().substring(0, node.key().length() - 1) + "\",");
+                            return replaceFirstLiteral(json, node.key(), node.key().substring(0, node.key().length() - 1) + "\",");
                         }
                     }
-                    return json.replaceFirst(node.key(), node.key() + "\"");
+                    return replaceFirstLiteral(json, node.key(), node.key() + "\"");
                 }),
         OPEN_QUOTATION_MARK(
                 (node, beRepairParseList) -> node.expectingToken() && node.key().endsWith("\""),
-                (json, node, beRepairParseList) -> json.replaceFirst(node.key(), "\"" + node.key())),
+                (json, node, beRepairParseList) -> replaceFirstLiteral(json, node.key(), "\"" + node.key())),
         STRING_QUOTATION_MARK(
                 (node, beRepairParseList) -> node.expectingToken() && node.key().endsWith(KeySymbol.COLON.val()),
-                (json, node, beRepairParseList) -> json.replaceFirst(node.key(), "\"" + node.key().substring(0, node.key().length() - 1) + "\":")),
+                (json, node, beRepairParseList) -> replaceFirstLiteral(json, node.key(), "\"" + node.key().substring(0, node.key().length() - 1) + "\":")),
         VALUE_QUOTATION_MARK(
                 (node, beRepairParseList) -> node.expectingToken(),
-                (json, node, beRepairParseList) -> json.replaceFirst(node.key(), "\"" + node.key() + "\"")),
+                (json, node, beRepairParseList) -> replaceFirstLiteral(json, node.key(), "\"" + node.key() + "\"")),
         CLOSE_BRACE(
                 (node, beRepairParseList) -> beRepairParseList.stream().anyMatch(
                         (parse) -> parse instanceof ErrorNode

--- a/src/test/resources/case/simple.xml
+++ b/src/test/resources/case/simple.xml
@@ -146,4 +146,28 @@
             }
         </correct>
     </test-case>
+    <test-case>
+        <anomaly><![CDATA[
+[
+    {
+        "name": "WriteTool.write",
+        "args": {
+            "filePath": "ai-llm-ppt/index.html",
+            "content": "<div class=\"test">hello</div>"
+        }
+    }
+]
+        ]]></anomaly>
+        <correct><![CDATA[
+[
+    {
+        "name": "WriteTool.write",
+        "args": {
+            "filePath": "ai-llm-ppt/index.html",
+            "content": "<div class=\"test\">hello</div>"
+        }
+    }
+]
+        ]]></correct>
+    </test-case>
 </test-cases>


### PR DESCRIPTION
Fixes #34

This change repairs a quote inside a JSON string when the quote is not followed by a JSON structural token. For the reported input, `class=\"test">` is repaired to `class=\"test\">`.

It also changes quote repair replacements in `SimpleRepairStrategy` to literal string replacement. The previous `replaceFirst` calls treated malformed JSON fragments as regex patterns, which can fail when the fragment contains `\`.

Validation:

- `./mvnw clean test` passed: 62 tests run, 0 failures, 0 errors, 1 skipped
- `./mvnw -q spotless:check` passed
- `./mvnw -q -DskipTests package dependency:build-classpath -Dmdep.outputFile=target/classpath.txt` passed
- Ran the issue sample with `JSONRepair.handle(...)`; it now outputs `class=\"test\">hello</div>`
